### PR TITLE
Improve `decodeHex` performance on non-Jvm platforms.

### DIFF
--- a/encoding/src/commonMain/kotlin/diglol/encoding/internal/commonHex.kt
+++ b/encoding/src/commonMain/kotlin/diglol/encoding/internal/commonHex.kt
@@ -38,12 +38,9 @@ internal fun ByteArray.commonDecodeHex(): ByteArray? {
   return out
 }
 
-@Suppress("NOTHING_TO_INLINE")
-private inline fun Byte.decodeToInt(): Int? {
-  return when (this) {
-    in '0'.code..'9'.code -> this - '0'.code
-    in 'a'.code..'f'.code -> this - 'a'.code + 10
-    in 'A'.code..'F'.code -> this - 'A'.code + 10
-    else -> null
-  }
+private inline fun Byte.decodeToInt(): Int? = when (val input = toInt()) {
+  in '0'.code..'9'.code -> input - '0'.code
+  in 'a'.code..'f'.code -> input - 'a'.code + 10
+  in 'A'.code..'F'.code -> input - 'A'.code + 10
+  else -> null
 }


### PR DESCRIPTION
old:
```
macosArm64 summary:
Benchmark                       (dataSize)  Mode  Cnt     Score     Error  Units
HexBenchmark.decodeHexToBytes         1024  avgt    5    90.516 ±   1.289  us/op
HexBenchmark.decodeHexToBytes        10240  avgt    5   970.772 ±  14.415  us/op
HexBenchmark.decodeHexToBytes       102400  avgt    5  9599.706 ± 111.556  us/op
HexBenchmark.decodeHex                1024  avgt    5    86.198 ±   1.073  us/op
HexBenchmark.decodeHex               10240  avgt    5   903.644 ±  13.339  us/op
HexBenchmark.decodeHex              102400  avgt    5  9394.342 ± 251.052  us/op
HexBenchmark.encodeHexToString        1024  avgt    5    10.703 ±   0.376  us/op
HexBenchmark.encodeHexToString       10240  avgt    5   102.742 ±   0.649  us/op
HexBenchmark.encodeHexToString      102400  avgt    5  1054.671 ±  14.978  us/op
HexBenchmark.encodeHex                1024  avgt    5     1.506 ±   0.005  us/op
HexBenchmark.encodeHex               10240  avgt    5    14.596 ±   0.155  us/op
HexBenchmark.encodeHex              102400  avgt    5   149.446 ±   1.464  us/op

js summary:
Benchmark                       (dataSize)  Mode  Cnt     Score    Error  Units
HexBenchmark.decodeHex                1024  avgt    5    88.867 ±  2.017  us/op
HexBenchmark.decodeHex               10240  avgt    5   739.243 ± 20.750  us/op
HexBenchmark.decodeHex              102400  avgt    5  7202.033 ± 76.533  us/op
HexBenchmark.decodeHexToBytes         1024  avgt    5    72.025 ±  0.441  us/op
HexBenchmark.decodeHexToBytes        10240  avgt    5   715.291 ±  1.447  us/op
HexBenchmark.decodeHexToBytes       102400  avgt    5  7166.035 ± 18.687  us/op
HexBenchmark.encodeHex                1024  avgt    5     3.321 ±  0.004  us/op
HexBenchmark.encodeHex               10240  avgt    5    32.133 ±  0.034  us/op
HexBenchmark.encodeHex              102400  avgt    5   319.168 ±  2.099  us/op
HexBenchmark.encodeHexToString        1024  avgt    5     6.651 ±  0.417  us/op
HexBenchmark.encodeHexToString       10240  avgt    5    51.162 ±  0.464  us/op
HexBenchmark.encodeHexToString      102400  avgt    5   559.632 ±  7.479  us/op
```

new:
```
macosArm64 summary:
Benchmark                       (dataSize)  Mode  Cnt     Score    Error  Units
HexBenchmark.decodeHexToBytes         1024  avgt    5    12.213 ±  0.044  us/op
HexBenchmark.decodeHexToBytes        10240  avgt    5   149.242 ±  0.321  us/op
HexBenchmark.decodeHexToBytes       102400  avgt    5  1546.013 ±  2.679  us/op
HexBenchmark.decodeHex                1024  avgt    5     7.651 ±  0.324  us/op
HexBenchmark.decodeHex               10240  avgt    5   104.103 ±  1.176  us/op
HexBenchmark.decodeHex              102400  avgt    5  1100.247 ±  2.839  us/op
HexBenchmark.encodeHexToString        1024  avgt    5    10.470 ±  0.041  us/op
HexBenchmark.encodeHexToString       10240  avgt    5   108.126 ±  3.108  us/op
HexBenchmark.encodeHexToString      102400  avgt    5  1081.636 ± 29.467  us/op
HexBenchmark.encodeHex                1024  avgt    5     1.569 ±  0.039  us/op
HexBenchmark.encodeHex               10240  avgt    5    15.093 ±  0.279  us/op
HexBenchmark.encodeHex              102400  avgt    5   149.750 ±  0.754  us/op

js summary:
Benchmark                       (dataSize)  Mode  Cnt    Score   Error  Units
HexBenchmark.decodeHex                1024  avgt    5    4.231 ± 0.035  us/op
HexBenchmark.decodeHex               10240  avgt    5   75.777 ± 0.793  us/op
HexBenchmark.decodeHex              102400  avgt    5  910.915 ± 5.018  us/op
HexBenchmark.decodeHexToBytes         1024  avgt    5    5.177 ± 0.044  us/op
HexBenchmark.decodeHexToBytes        10240  avgt    5   84.984 ± 0.573  us/op
HexBenchmark.decodeHexToBytes       102400  avgt    5  996.811 ± 3.988  us/op
HexBenchmark.encodeHex                1024  avgt    5    3.294 ± 0.007  us/op
HexBenchmark.encodeHex               10240  avgt    5   32.077 ± 0.062  us/op
HexBenchmark.encodeHex              102400  avgt    5  318.145 ± 0.234  us/op
HexBenchmark.encodeHexToString        1024  avgt    5    6.547 ± 0.220  us/op
HexBenchmark.encodeHexToString       10240  avgt    5   50.547 ± 0.158  us/op
HexBenchmark.encodeHexToString      102400  avgt    5  540.075 ± 5.027  us/op
```